### PR TITLE
Fix target selectors in the admin settings form

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -23,7 +23,7 @@ form:
       validate:
         type: bool
     index:
-      type: toggle
+      type: select
       label: PLUGIN_STATIC_GENERATOR.ADMIN.STORAGE.INDEX
       description: PLUGIN_STATIC_GENERATOR.ADMIN.DESCRIPTION.STORAGE.INDEX
       highlight: native
@@ -33,9 +33,9 @@ form:
         persist: PLUGIN_STATIC_GENERATOR.ADMIN.STORAGE.OPTIONS.PERSIST
         transient: PLUGIN_STATIC_GENERATOR.ADMIN.STORAGE.OPTIONS.TRANSIENT
       validate:
-        type: bool
+        required: true
     content:
-      type: toggle
+      type: select
       label: PLUGIN_STATIC_GENERATOR.ADMIN.STORAGE.CONTENT
       description: PLUGIN_STATIC_GENERATOR.ADMIN.DESCRIPTION.STORAGE.CONTENT
       highlight: native
@@ -45,7 +45,7 @@ form:
         persist: PLUGIN_STATIC_GENERATOR.ADMIN.STORAGE.OPTIONS.PERSIST
         transient: PLUGIN_STATIC_GENERATOR.ADMIN.STORAGE.OPTIONS.TRANSIENT
       validate:
-        type: bool
+        required: true
     addendum:
       type: spacer
       text: PLUGIN_STATIC_GENERATOR.ADMIN.DESCRIPTION.STORAGE.ADDENDUM


### PR DESCRIPTION
The target for `index` and `content` can't be set using the admin interface, since the validation causes any selection to be stored as `true` instead of the actual value in the YAML file. This can be observed in the settings form as none of the options is selected after saving.

Removing the validation fixes this issue. This is also the way it is done in the core blueprints (cf. e.g. [system.yaml:1252](https://github.com/getgrav/grav/blob/develop/system/blueprints/config/system.yaml#L1252))