### PR TITLE
Fix error output for invalid target

### DIFF
--- a/cli/GenerateStaticPageCommand.php
+++ b/cli/GenerateStaticPageCommand.php
@@ -96,7 +96,7 @@ class GenerateStaticPageCommand extends ConsoleCommand
                 $scheme = parse_url($target, PHP_URL_SCHEME);
                 $location = $locator->findResource($scheme . '://') . str_replace($scheme . '://', '/', $target);
             } else {
-                $this->output->error('<error>Target must be a valid stream resource, prefixing one of:</error>');
+                $this->output->writeln('<error>Target must be a valid stream resource, prefixing one of:</error>');
                 foreach ($locator->getSchemes() as $scheme) {
                     $this->output->writeln($scheme . '://');
                 }


### PR DESCRIPTION
When passing an invalid target (or having one set in the configuration) to the static page generation command, the output of the error itself generates a PHP fatal error since the `error` method is not defined for the output object.

This PR just replaces this call with `writeln` as in the corresponding line in [GenerateStaticIndexCommand.php](https://github.com/OleVik/grav-plugin-static-generator/blob/master/cli/GenerateStaticIndexCommand.php#L126).

However, since the code for parsing the target is now completely identical in both files, it would probably be best to extract it to a function. But, as a large part of it outputs to the console, I'm not quite sure where to place it or to what degree that refactoring would make sense.